### PR TITLE
Add Geometry support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,16 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
 
+      - name: Install sqlite3 and spatialite libraries
+        run: |
+          sudo apt-get install --yes --no-install-recommends sqlite3 libsqlite3-mod-spatialite
+
       - name: Install python dependencies
         shell: bash
         run: |
           pip install --disable-pip-version-check --upgrade pip setuptools wheel
           pip install ${{ matrix.deps }}
-          pip install -e .[test,geo]
+          pip install -e .[test]
           pip list
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
         include:
           # 2017
           - python: 3.6
-            deps: "numpy==1.13.* sqlalchemy==1.1.* geoalchemy2==0.4.* pygeos==0.5.*"
+            deps: "numpy==1.13.* sqlalchemy==1.1.* geoalchemy2==0.6.* pygeos==0.5.*"
           # 2018
           - python: 3.7
-            deps: "numpy==1.15.* sqlalchemy==1.2.* geoalchemy2==0.5.* pygeos==0.7.*"
+            deps: "numpy==1.15.* sqlalchemy==1.2.* geoalchemy2==0.6.* pygeos==0.7.*"
           # 2019
           - python: 3.8
             deps: "numpy==1.17.* sqlalchemy==1.3.* geoalchemy2==0.6.* pygeos==0.8.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         include:
           # 2017
           - python: 3.6
-            deps: "numpy==1.13.* sqlalchemy==1.1.* geoalchemy2==0.6.* pygeos==0.5.*"
+            deps: "numpy==1.13.* sqlalchemy==1.1.* geoalchemy2==0.6.* pygeos==0.7.*"
           # 2018
           - python: 3.7
             deps: "numpy==1.15.* sqlalchemy==1.2.* geoalchemy2==0.6.* pygeos==0.7.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   TestLinux:
-    name: Python ${{ matrix.python }}
+    name: Python ${{ matrix.python }} ${{ matrix.display_name }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -20,26 +20,32 @@ jobs:
             numpy: "1.13.*"
             sqlalchemy: "1.1.*"
             geoalchemy2: "0.4.*"
+            pygeos: "0.5.*"
           # 2018
           - python: 3.7
             numpy: "1.15.*"
             sqlalchemy: "1.2.*"
             geoalchemy2: "0.5.*"
+            pygeos: "0.7.*"
           # 2019
           - python: 3.8
             numpy: "1.17.*"
             sqlalchemy: "1.3.*"
             geoalchemy2: "0.6.*"
+            pygeos: "0.8.*"
           # 2020
           - python: 3.9
             numpy: "1.19.*"
             sqlalchemy: "1.3.*"
             geoalchemy2: "0.7.*"
+            pygeos: "0.9.*"
           # current
           - python: 3.9
+            display_name: "latest"
             numpy: "1.*"
             sqlalchemy: "1.*"
             geoalchemy2: "0.8.*"
+            pygeos: "0.*"
           # current - no optional deps
           - python: 3.9
             numpy: "1.*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,39 +17,24 @@ jobs:
         include:
           # 2017
           - python: 3.6
-            numpy: "1.13.*"
-            sqlalchemy: "1.1.*"
-            geoalchemy2: "0.4.*"
-            pygeos: "0.5.*"
+            deps: "numpy==1.13.* sqlalchemy==1.1.* geoalchemy2==0.4.* pygeos==0.5.*"
           # 2018
           - python: 3.7
-            numpy: "1.15.*"
-            sqlalchemy: "1.2.*"
-            geoalchemy2: "0.5.*"
-            pygeos: "0.7.*"
+            deps: "numpy==1.15.* sqlalchemy==1.2.* geoalchemy2==0.5.* pygeos==0.7.*"
           # 2019
           - python: 3.8
-            numpy: "1.17.*"
-            sqlalchemy: "1.3.*"
-            geoalchemy2: "0.6.*"
-            pygeos: "0.8.*"
+            deps: "numpy==1.17.* sqlalchemy==1.3.* geoalchemy2==0.6.* pygeos==0.8.*"
           # 2020
           - python: 3.9
-            numpy: "1.19.*"
-            sqlalchemy: "1.3.*"
-            geoalchemy2: "0.7.*"
-            pygeos: "0.9.*"
+            deps: "numpy==1.19.* sqlalchemy==1.3.* geoalchemy2==0.7.* pygeos==0.9.*"
           # current
           - python: 3.9
             display_name: "latest"
-            numpy: "1.*"
-            sqlalchemy: "1.*"
-            geoalchemy2: "0.8.*"
-            pygeos: "0.*"
+            deps: "numpy sqlalchemy geoalchemy2 pygeos"
           # current - no optional deps
           - python: 3.9
-            numpy: "1.*"
-            sqlalchemy: "1.*"
+            display_name: "no geo"
+            deps: "numpy sqlalchemy"
 
 
     steps:
@@ -64,7 +49,8 @@ jobs:
         shell: bash
         run: |
           pip install --disable-pip-version-check --upgrade pip setuptools wheel
-          pip install pytest numpy==${{ matrix.numpy }} sqlalchemy==${{ matrix.sqlalchemy }}
+          pip install ${{ matrix.deps }}
+          pip install -e .[test,geo]
           pip list
 
       - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,30 @@ jobs:
         include:
           # 2017
           - python: 3.6
-            numpy: 1.13.3
-            sqlalchemy: 1.1
+            numpy: "1.13.*"
+            sqlalchemy: "1.1.*"
+            geoalchemy2: "0.4.*"
           # 2018
           - python: 3.7
-            numpy: 1.15.4
-            sqlalchemy: 1.2
+            numpy: "1.15.*"
+            sqlalchemy: "1.2.*"
+            geoalchemy2: "0.5.*"
           # 2019
           - python: 3.8
-            numpy: 1.17.5
-            sqlalchemy: 1.3
+            numpy: "1.17.*"
+            sqlalchemy: "1.3.*"
+            geoalchemy2: "0.6.*"
+          # 2020
+          - python: 3.9
+            numpy: "1.19.*"
+            sqlalchemy: "1.3.*"
+            geoalchemy2: "0.7.*"
           # current
+          - python: 3.9
+            numpy: "1.*"
+            sqlalchemy: "1.*"
+            geoalchemy2: "0.8.*"
+          # current - no optional deps
           - python: 3.9
             numpy: "1.*"
             sqlalchemy: "1.*"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,4 +4,22 @@ Changelog of threedi-modelchecker
 0.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Basic project structure.
+
+- Added ``NumpyQuery`` to override ``query_cls`` in the SQLAlchemy sessionmaker.
+
+- Added ``NumpyQueryMixin`` to adapt existing custom query classes.
+
+- Implemented ``NumpyQuery().numpy_dtype``.
+
+- Implemented ``NumpyQuery().as_structarray``.
+
+- Implemented ``NumpyQuery().with_numpy_cast_columns``.
+
+- Implemented ``NumpyQuery().numpy_settings`` and 
+  ``NumpyQuery.default_numpy_settings``.
+
+- Enabled bulk reading of Boolean, Float, Integer, Numeric, String, Text.
+
+- Added optional dependency ``condenser[geo]`` which enables bulk reading of
+  Geometry columns through GeoAlchemy2 into an array of ``pygeos.Geometry``.

--- a/README.rst
+++ b/README.rst
@@ -33,15 +33,16 @@ Custom dtype mapping
 
 Condenser has a safe approach on guessing the Numpy dtypes from SQLAlchemy
 dtypes. It always takes 8-byte signed integers and floats. For some database
-backends this could be more strict. Override the type mapping when constructing
+backends this could be more strict. Override the type mapping after constructing
 the query::
 
 >>> from sqlalchemy import Integer
->>> query = session.query(SomeModel.float_type_column, type_mapping={Integer: np.int32})
+>>> query = session.query(SomeModel.float_type_column)
+>>> NumpyQuery.numpy_settings[Integer]["dtype"] = np.int32
 
 Or globally::
 
->>> NumpyQuery.default_type_mapping[Integer] = np.int32
+>>> NumpyQuery.default_numpy_settings[Integer]["dtype"] = np.int32
 
 
 Credits

--- a/condenser/query.py
+++ b/condenser/query.py
@@ -1,13 +1,13 @@
-import numpy as np
-import copy
-from sqlalchemy.orm.query import Query
-
 from sqlalchemy import Boolean
 from sqlalchemy import Float
 from sqlalchemy import Integer
 from sqlalchemy import Numeric
 from sqlalchemy import String
 from sqlalchemy import Text
+from sqlalchemy.orm.query import Query
+
+import copy
+import numpy as np
 
 
 class NumpyQueryMixin:

--- a/condenser/query.py
+++ b/condenser/query.py
@@ -1,7 +1,5 @@
 import numpy as np
-from collections import defaultdict
 import copy
-from collections import defaultdict
 from sqlalchemy.orm.query import Query
 
 from sqlalchemy import Boolean

--- a/condenser/query.py
+++ b/condenser/query.py
@@ -56,7 +56,7 @@ class NumpyQueryMixin:
         for i, descr in enumerate(self.column_descriptions):
             settings = self.numpy_settings.get(descr["type"].__class__, {})
             dtype = settings.get("dtype", np.dtype("O"))
-            result.append((descr["name"] or "x{}".format(i), dtype))
+            result.append((descr["name"] or "f{}".format(i), dtype))
         return np.dtype(result)
 
     def with_numpy_cast_columns(self):
@@ -82,12 +82,15 @@ class NumpyQueryMixin:
         # Get the numpy dtype
         dtype = cast_query.numpy_dtype
 
-        # Cannot use np.fromiter with complex dtypes, so we go through a list
-        arr = np.array(list(cast_query), dtype=dtype)
-
         # insert the column names back in from the original query (it might
         # have been lost in the sql typecasts)
-        arr.dtype.names = [x["name"] for x in self.column_descriptions]
+        dtype.names = [
+            (x["name"] or "f{}".format(i))
+            for (i, x) in enumerate(self.column_descriptions)
+        ]
+
+        # Cannot use np.fromiter with complex dtypes, so we go through a list
+        arr = np.array(list(cast_query), dtype=dtype)
 
         for descr in self.column_descriptions:
             settings = self.numpy_settings.get(descr["type"].__class__, {})

--- a/condenser/query.py
+++ b/condenser/query.py
@@ -16,7 +16,7 @@ class NumpyQueryMixin:
     # The precise type mapping depends on the dialect.
     # Use 8-bytes to be safe (e.g. SQLite uses that by default)
     default_numpy_settings = {
-        Boolean: {"dtype": np.dtype(np.bool)},
+        Boolean: {"dtype": np.dtype(bool)},
         Float: {"dtype": np.dtype(np.float64)},
         Integer: {"dtype": np.dtype(np.int64)},
         Numeric: {"dtype": np.dtype(np.float64)},

--- a/condenser/tests/conftest.py
+++ b/condenser/tests/conftest.py
@@ -8,12 +8,11 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.event import listen
 from sqlalchemy.sql import select, func
 
-import os
 import pytest
 
 try:
-    from geoalchemy2.types import Geometry
-    import pygeos
+    from geoalchemy2.types import Geometry  # NOQA
+    import pygeos  # NOQA
 
     has_geo = True
 except ImportError:

--- a/condenser/tests/conftest.py
+++ b/condenser/tests/conftest.py
@@ -1,18 +1,38 @@
 from .schema import Base
 from .schema import ModelOne
 from condenser import NumpyQuery
+from condenser.utils import load_spatialite
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.event import listen
+from sqlalchemy.sql import select, func
 
 import os
 import pytest
+
+try:
+    from geoalchemy2.types import Geometry
+    import pygeos
+
+    has_geo = True
+except ImportError:
+    has_geo = False
+
+requires_geo = pytest.mark.skipif(not has_geo, reason="requires GeoAlchemy2 and pygeos")
 
 
 @pytest.fixture(scope="session")
 def db_engine(request):
     """yields a SQLAlchemy engine which is suppressed after the test session"""
     engine = create_engine("sqlite://")
+    if has_geo:
+        # https://geoalchemy-2.readthedocs.io/en/latest/spatialite_tutorial.html
+        listen(engine, "connect", load_spatialite)
+        conn = engine.connect()
+        conn.execute(select([func.InitSpatialMetaData()]))
+        conn.close()
+
     session_factory = scoped_session(sessionmaker(bind=engine))
 
     Base.metadata.create_all(engine)
@@ -24,6 +44,8 @@ def db_engine(request):
         col_bool=True,
         col_text="once upon a time",
     )
+    if has_geo:
+        record.col_geom = "POINT (2 3)"
 
     session = session_factory()
     session.add(record)
@@ -37,13 +59,13 @@ def db_engine(request):
 @pytest.fixture(scope="session")
 def db_session_factory(db_engine):
     """returns a SQLAlchemy scoped session factory"""
-    return scoped_session(sessionmaker(bind=db_engine))
+    return scoped_session(sessionmaker(bind=db_engine, query_cls=NumpyQuery))
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="function")
 def db_session(db_session_factory):
     """yields a SQLAlchemy connection which is rollbacked after the test"""
-    session = db_session_factory(query_cls=NumpyQuery)
+    session = db_session_factory()
 
     yield session
 

--- a/condenser/tests/schema.py
+++ b/condenser/tests/schema.py
@@ -4,7 +4,6 @@ from sqlalchemy import Float
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
-from sqlalchemy import Column
 from sqlalchemy.ext.declarative import declarative_base
 
 Base = declarative_base()

--- a/condenser/tests/schema.py
+++ b/condenser/tests/schema.py
@@ -4,8 +4,8 @@ from sqlalchemy import Float
 from sqlalchemy import Integer
 from sqlalchemy import String
 from sqlalchemy import Text
+from sqlalchemy import Column
 from sqlalchemy.ext.declarative import declarative_base
-
 
 Base = declarative_base()
 
@@ -18,3 +18,10 @@ class ModelOne(Base):
     col_str = Column(String(32))
     col_text = Column(Text)
     col_float = Column(Float)
+
+    try:
+        from geoalchemy2.types import Geometry
+
+        col_geom = Column(Geometry(geometry_type="POINT", management=True))
+    except ImportError:
+        pass

--- a/condenser/tests/test_query.py
+++ b/condenser/tests/test_query.py
@@ -48,7 +48,7 @@ def test_adapted_numpy_dtype(db_session, entity, expected_type):
     q = db_session.query(entity)
     q.numpy_settings[Integer]["dtype"] = np.int32
     assert q.numpy_dtype[0] == expected_type
-    
+
 
 def test_as_structarray(db_session):
     """Convert all records to a numpy structured array"""

--- a/condenser/tests/test_query.py
+++ b/condenser/tests/test_query.py
@@ -27,7 +27,7 @@ def test_query_cls(db_session):
         (ModelOne.col_float, np.float64),
         (ModelOne.col_str, np.dtype("O")),
         (ModelOne.col_text, np.dtype("O")),
-        (ModelOne.col_bool, np.bool),
+        (ModelOne.col_bool, np.dtype(bool)),
     ],
 )
 def test_numpy_dtype(db_session, entity, expected_type):

--- a/condenser/tests/test_query.py
+++ b/condenser/tests/test_query.py
@@ -36,6 +36,20 @@ def test_numpy_dtype(db_session, entity, expected_type):
     assert q.numpy_dtype[0] == expected_type
 
 
+@pytest.mark.parametrize(
+    "entity,expected_type",
+    [
+        (ModelOne.col_int, np.int32),  # adapted
+        (ModelOne.col_float, np.float64),  # untouched
+    ],
+)
+def test_adapted_numpy_dtype(db_session, entity, expected_type):
+    """Override type_mapping on the query instance"""
+    q = db_session.query(entity)
+    q.numpy_settings[Integer]["dtype"] = np.int32
+    assert q.numpy_dtype[0] == expected_type
+    
+
 def test_as_structarray(db_session):
     """Convert all records to a numpy structured array"""
     q = db_session.query(

--- a/condenser/utils.py
+++ b/condenser/utils.py
@@ -1,0 +1,28 @@
+def load_spatialite(con, connection_record):
+    """Load spatialite extension as described in
+    https://geoalchemy-2.readthedocs.io/en/latest/spatialite_tutorial.html"""
+    import sqlite3
+
+    con.enable_load_extension(True)
+    cur = con.cursor()
+    libs = [
+        # SpatiaLite >= 4.2 and Sqlite >= 3.7.17, should work on all platforms
+        ("mod_spatialite", "sqlite3_modspatialite_init"),
+        # SpatiaLite >= 4.2 and Sqlite < 3.7.17 (Travis)
+        ("mod_spatialite.so", "sqlite3_modspatialite_init"),
+        # SpatiaLite < 4.2 (linux)
+        ("libspatialite.so", "sqlite3_extension_init"),
+    ]
+    found = False
+    for lib, entry_point in libs:
+        try:
+            cur.execute("select load_extension('{}', '{}')".format(lib, entry_point))
+        except sqlite3.OperationalError:
+            continue
+        else:
+            found = True
+            break
+    if not found:
+        raise RuntimeError("Cannot find any suitable spatialite module")
+    cur.close()
+    con.enable_load_extension(False)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     description="A fast interface between SQLAlchemy and Numpy",
     install_requires=["sqlalchemy>=1.1", "numpy>=1.13"],
-    extras_require={"test": ["pytest>=3"], "geo": ["geoalchemy2>=0.4", "pygeos>=0.5"]},
+    extras_require={"test": ["pytest>=3"], "geo": ["geoalchemy2>=0.6", "pygeos>=0.5"]},
     license="BSD license",
     long_description=readme,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     ],
     description="A fast interface between SQLAlchemy and Numpy",
     install_requires=requirements,
+    extras_require={"geo": ["geoalchemy2", "pygeos"]},
     license="BSD license",
     long_description=readme,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     ],
     description="A fast interface between SQLAlchemy and Numpy",
     install_requires=["sqlalchemy>=1.1", "numpy>=1.13"],
-    extras_require={"test": ["pytest>=3"], "geo": ["geoalchemy2>=0.6", "pygeos>=0.5"]},
+    extras_require={"test": ["pytest>=3"], "geo": ["geoalchemy2>=0.6", "pygeos>=0.7"]},
     license="BSD license",
     long_description=readme,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     ],
     description="A fast interface between SQLAlchemy and Numpy",
     install_requires=requirements,
-    extras_require={"geo": ["geoalchemy2", "pygeos"]},
+    extras_require={"geo": ["geoalchemy2>=0.4", "pygeos>=0.5"]},
     license="BSD license",
     long_description=readme,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -4,39 +4,34 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst") as readme_file:
     readme = readme_file.read()
-
-requirements = ["sqlalchemy", "numpy"]
-
-test_requirements = ['pytest>=3', ]
 
 setup(
     author="Casper van der Wel",
-    author_email='caspervdw@gmail.com',
-    python_requires='>=3.5',
+    author_email="caspervdw@gmail.com",
+    python_requires=">=3.5",
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
+        "Development Status :: 2 - Pre-Alpha",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     description="A fast interface between SQLAlchemy and Numpy",
-    install_requires=requirements,
-    extras_require={"geo": ["geoalchemy2>=0.4", "pygeos>=0.5"]},
+    install_requires=["sqlalchemy>=1.1", "numpy>=1.13"],
+    extras_require={"test": ["pytest>=3"], "geo": ["geoalchemy2>=0.4", "pygeos>=0.5"]},
     license="BSD license",
     long_description=readme,
     include_package_data=True,
-    keywords='condenser',
-    name='condenser',
-    packages=find_packages(include=['condenser', 'condenser.*']),
-    tests_require=test_requirements,
-    url='https://github.com/nens/condenser',
-    version='0.1.0',
+    keywords="condenser",
+    name="condenser",
+    packages=["condenser"],
+    url="https://github.com/nens/condenser",
+    version="0.1.0",
     zip_safe=False,
 )


### PR DESCRIPTION
This adds optional support for reading geometries via GeoAlchemy2 into a pygeos array. By going through WKB a decent performance is reached.

To be able to go through WKB, the SQL query needs an explicit cast `ST_ToBinary`. Then after reading into an array, we need to construct the pygeos geometries using `pygeos.from_wkb`. To pave the way for issues #6 and #2, I made both these typecasts configurable.

Disclaimer about pygeos: I wrote this package, but it is being picked up by the community and I am not longer the only contributor. Work is in progress to merge it with shapely, which has a much larger use base.
