### PR TITLE
Reproject geometries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,3 +23,5 @@ Changelog of threedi-modelchecker
 
 - Added optional dependency ``condenser[geo]`` which enables bulk reading of
   Geometry columns through GeoAlchemy2 into an array of ``pygeos.Geometry``.
+
+- Added ``NumpyQuery().with_transformed_geometries``.

--- a/condenser/query.py
+++ b/condenser/query.py
@@ -79,7 +79,9 @@ class NumpyQueryMixin:
         return self.with_entities(*new_columns)
 
     def as_structarray(self):
-        """Read all records from this query into a numpy structured array.
+        """Read all entities in this query into a numpy structured array.
+
+        Every entity is mapped to a column in the structured array.
 
         Specific types are converted into numpy datatypes. This is configured
         through ``self.numpy_settings``.
@@ -102,8 +104,18 @@ class NumpyQueryMixin:
 
         return arr
 
-    def transform_geom(self, target_srid):
-        """Transform all SRID-aware columns to given target SRID"""
+    def with_transformed_geometries(self, target_srid):
+        """Transform all SRID-aware columns to given target SRID
+
+        Args:
+          target_srid (int): The SRID to reproject the geometries into.
+
+        See also:
+          Columns that are not SRID-aware do not support coordinate
+          transformations. If an SRID is known from metadata, use a function
+          appropriate to your database backend to set it (e.g. `ST_SetSRID`
+          for PostGIS and `setsrid` for SQLite/spatialite)
+        """
         if not has_geo:
             raise ImportError("This function requires GeoAlchemy2 and pygeos")
         srid = int(target_srid)

--- a/condenser/tests/conftest.py
+++ b/condenser/tests/conftest.py
@@ -1,7 +1,7 @@
 from .schema import Base
 from .schema import ModelOne
 from condenser import NumpyQuery
-from condenser.utils import load_spatialite
+from condenser.utils import load_spatialite, has_geo
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session
 from sqlalchemy.orm import sessionmaker
@@ -9,14 +9,6 @@ from sqlalchemy.event import listen
 from sqlalchemy.sql import select, func
 
 import pytest
-
-try:
-    from geoalchemy2.types import Geometry  # NOQA
-    import pygeos  # NOQA
-
-    has_geo = True
-except ImportError:
-    has_geo = False
 
 requires_geo = pytest.mark.skipif(not has_geo, reason="requires GeoAlchemy2 and pygeos")
 
@@ -45,6 +37,7 @@ def db_engine(request):
     )
     if has_geo:
         record.col_geom = "POINT (2 3)"
+        record.col_geom_4326 = "SRID=4326;POINT (0 0)"
 
     session = session_factory()
     session.add(record)

--- a/condenser/tests/conftest.py
+++ b/condenser/tests/conftest.py
@@ -37,7 +37,7 @@ def db_engine(request):
     )
     if has_geo:
         record.col_geom = "POINT (2 3)"
-        record.col_geom_4326 = "SRID=4326;POINT (0 0)"
+        record.col_geom_4326 = "SRID=4326;POINT (5.115651 52.092840)"
 
     session = session_factory()
     session.add(record)

--- a/condenser/tests/schema.py
+++ b/condenser/tests/schema.py
@@ -22,6 +22,8 @@ class ModelOne(Base):
         from geoalchemy2.types import Geometry
 
         col_geom = Column(Geometry(geometry_type="POINT", management=True))
-        col_geom_4326 = Column(Geometry(geometry_type="POINT", management=True, srid=4326))
+        col_geom_4326 = Column(
+            Geometry(geometry_type="POINT", management=True, srid=4326)
+        )
     except ImportError:
         pass

--- a/condenser/tests/schema.py
+++ b/condenser/tests/schema.py
@@ -22,5 +22,6 @@ class ModelOne(Base):
         from geoalchemy2.types import Geometry
 
         col_geom = Column(Geometry(geometry_type="POINT", management=True))
+        col_geom_4326 = Column(Geometry(geometry_type="POINT", management=True, srid=4326))
     except ImportError:
         pass

--- a/condenser/tests/test_query.py
+++ b/condenser/tests/test_query.py
@@ -77,3 +77,13 @@ def test_geometry(db_session):
 
     # see conftest.py
     assert actual["col_geom"][0] == pygeos.points(2, 3)
+
+
+@requires_geo
+def test_geometry_transform(db_session):
+    """Convert all records to a numpy structured array"""
+    q = db_session.query(ModelOne.col_geom_4326).transform_geom(3857)
+    actual = q.as_structarray()
+
+    # see conftest.py
+    assert actual["col_geom"][0] == pygeos.points(2, 3)

--- a/condenser/tests/test_query.py
+++ b/condenser/tests/test_query.py
@@ -82,7 +82,7 @@ def test_geometry(db_session):
 @requires_geo
 def test_geometry_transform(db_session):
     """Reproject a column that has 4326 projection"""
-    q = db_session.query(ModelOne.col_geom_4326).transform_geom(3857)
+    q = db_session.query(ModelOne.col_geom_4326).with_transformed_geometries(3857)
     actual = q.as_structarray()
 
     # see conftest.py for the EPSG4326 coordinates
@@ -94,7 +94,7 @@ def test_geometry_transform(db_session):
 @requires_geo
 def test_geometry_transform_unknown_input_srid(db_session):
     """Attempt to reproject a column that has no projection"""
-    q = db_session.query(ModelOne.col_geom).transform_geom(3857)
+    q = db_session.query(ModelOne.col_geom).with_transformed_geometries(3857)
     actual = q.as_structarray()
 
     # see conftest.py

--- a/condenser/utils.py
+++ b/condenser/utils.py
@@ -1,3 +1,11 @@
+try:
+    import geoalchemy2  # NOQA
+    import pygeos  # NOQA
+    has_geo = True
+except ImportError:
+    has_geo = False
+
+
 def load_spatialite(con, connection_record):
     """Load spatialite extension as described in
     https://geoalchemy-2.readthedocs.io/en/latest/spatialite_tutorial.html"""

--- a/condenser/utils.py
+++ b/condenser/utils.py
@@ -1,6 +1,7 @@
 try:
     import geoalchemy2  # NOQA
     import pygeos  # NOQA
+
     has_geo = True
 except ImportError:
     has_geo = False


### PR DESCRIPTION
This adds `with_transformed_geometries` that transforms geometry columns ("entities" in SQLAlchemy language) into the requested srid.