### PR TITLE
Fix for sqlalchemy 1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog of condenser
 0.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- SQLAlchemy 1.4 compatibility fix (#10).
 
 
 0.1.0 (2021-02-22)

--- a/condenser/query.py
+++ b/condenser/query.py
@@ -92,14 +92,15 @@ class NumpyQueryMixin:
         Specific types are converted into numpy datatypes. This is configured
         through ``self.numpy_settings``.
         """
-        # Apply casts
+        # Apply casts and get the data
         cast_query = self.with_numpy_entities()
+        data = list(cast_query)
 
-        # Get the numpy dtype
-        dtype = cast_query.numpy_dtype
-
-        # Cannot use np.fromiter with complex dtypes, so we go through a list
-        arr = np.array(list(cast_query), dtype=dtype)
+        # Cannot use np.fromiter or np.array directly (because have a list
+        # of tuples/Row instances to iterate over)
+        arr = np.empty((len(data),), dtype=cast_query.numpy_dtype)
+        for i in range(len(data)):
+            arr[i] = tuple(data[i])
 
         # Execute numpy typecasts if present
         for descr in self.column_descriptions:


### PR DESCRIPTION
Apparently np.array(list(query)) does not work anymore because the returned objects are not tuples anymore in SQLAlchemy 1.4, but instances of Row.

See here for the change:
https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#the-keyedtuple-object-returned-by-query-is-replaced-by-row

I adapted the implementation to deal with this.
I checked `get_channels()` in threedigrid-builder with this new implementation, and the timings didn't change.